### PR TITLE
Curry coroutine name in safe_ensure_future

### DIFF
--- a/birdfeeder/async_utils.py
+++ b/birdfeeder/async_utils.py
@@ -67,7 +67,12 @@ def safe_ensure_future(coro, *args, **kwargs):
                 exc_info=True,
             )
 
-    return asyncio.ensure_future(safe_wrapper(coro), *args, **kwargs)
+    wrapped_coro = safe_wrapper(coro)
+
+    if coro.__name__ and isinstance(coro.__name__, str) and coro.__name__.isidentifier():
+        wrapped_coro.__qualname__ = f"safe_{coro.__qualname__}"
+
+    return asyncio.ensure_future(wrapped_coro, *args, **kwargs)
 
 
 async def safe_gather(*args, **kwargs):

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -59,6 +59,13 @@ async def test_safe_ensure_future_2(caplog):
 
 
 @pytest.mark.asyncio()
+async def test_safe_ensure_future_named_1():
+    safe_wrapped = async_utils.safe_ensure_future(ok_coroutine())
+    await safe_wrapped
+    assert 'safe_ok_coroutine' in repr(safe_wrapped)
+
+
+@pytest.mark.asyncio()
 async def test_safe_gather_1():
     await async_utils.safe_gather(ok_coroutine())
 


### PR DESCRIPTION
This PR allows the original coroutine name to be printed in the resulting Task's `repr()`, which can be helpful when warnings such as "Task was destroyed but it is pending" are printed.

An example:

```py
import asyncio
from birdfeeder.async_utils import safe_ensure_future

async def stuff_and_things(): pass
async def yo_dawg(): pass
async def whats_up(): pass

async def main():
    safe_ensure_future(stuff_and_things()).__del__()
    safe_ensure_future(yo_dawg()).__del__()
    safe_ensure_future(whats_up()).__del__()

asyncio.get_event_loop().run_until_complete(main())
```

Output without these changes:
```
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<safe_ensure_future.<locals>.safe_wrapper() running at /home/they4kman/programming/coinalpha/birdfeeder/birdfeeder/async_utils.py:59>>
Task was destroyed but it is pending!
task: <Task pending name='Task-3' coro=<safe_ensure_future.<locals>.safe_wrapper() running at /home/they4kman/programming/coinalpha/birdfeeder/birdfeeder/async_utils.py:59>>
Task was destroyed but it is pending!
task: <Task pending name='Task-4' coro=<safe_ensure_future.<locals>.safe_wrapper() running at /home/they4kman/programming/coinalpha/birdfeeder/birdfeeder/async_utils.py:59>>
```

Output with these changes:
```
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<safe_stuff_and_things() running at /home/they4kman/programming/coinalpha/birdfeeder/birdfeeder/async_utils.py:59>>
Task was destroyed but it is pending!
task: <Task pending name='Task-3' coro=<safe_yo_dawg() running at /home/they4kman/programming/coinalpha/birdfeeder/birdfeeder/async_utils.py:59>>
Task was destroyed but it is pending!
task: <Task pending name='Task-4' coro=<safe_whats_up() running at /home/they4kman/programming/coinalpha/birdfeeder/birdfeeder/async_utils.py:59>>
```